### PR TITLE
Use the name for the custom field when showing them in the overview

### DIFF
--- a/imports/api/globalsettings/globalsettings.js
+++ b/imports/api/globalsettings/globalsettings.js
@@ -99,4 +99,7 @@ defaultSettings.push({
 defaultSettings.push({
   name: 'showCustomerInDetails', description: 'settings.show_customer_in_details', type: 'text', value: 'true',
 })
+defaultSettings.push({
+  name: 'showNameOfCustomFieldInDetails', description: 'settings.show_name_custom_field_in_details', type: 'text', value: false,
+})
 export { defaultSettings, Globalsettings }

--- a/imports/ui/components/detailtimetable.js
+++ b/imports/ui/components/detailtimetable.js
@@ -27,6 +27,11 @@ const Counts = new Mongo.Collection('counts')
 
 dayjs.extend(utc)
 
+let customFieldType = 'desc';
+if (getGlobalSetting('showNameOfCustomFieldInDetails')) {
+  customFieldType = 'name';
+}
+
 function detailedDataTableMapper(entry) {
   const project = Projects.findOne({ _id: entry.projectId })
   const mapping = [project ? project.name : '',
@@ -36,12 +41,12 @@ function detailedDataTableMapper(entry) {
   if (getGlobalSetting('showCustomFieldsInDetails')) {
     if (CustomFields.find({ classname: 'time_entry' }).count() > 0) {
       for (const customfield of CustomFields.find({ classname: 'time_entry' }).fetch()) {
-        mapping.push(entry[customfield.name])
+        mapping.push(entry[customfield[customFieldType]])
       }
     }
     if (CustomFields.find({ classname: 'project' }).count() > 0) {
       for (const customfield of CustomFields.find({ classname: 'project' }).fetch()) {
-        mapping.push(project[customfield.name])
+        mapping.push(project[customfield[customFieldType]])
       }
     }
   }
@@ -130,7 +135,7 @@ Template.detailtimetable.onRendered(() => {
         if (CustomFields.find({ classname: 'time_entry' }).count() > 0) {
           for (const customfield of CustomFields.find({ classname: 'time_entry' }).fetch()) {
             columns.push({
-              name: customfield.name,
+              name: customfield[customFieldType],
               editable: false,
               format: addToolTipToTableCell,
             })
@@ -139,7 +144,7 @@ Template.detailtimetable.onRendered(() => {
         if (CustomFields.find({ classname: 'project' }).count() > 0) {
           for (const customfield of CustomFields.find({ classname: 'project' }).fetch()) {
             columns.push({
-              name: customfield.name,
+              name: customfield[customFieldType],
               editable: false,
               format: addToolTipToTableCell,
             })
@@ -296,10 +301,10 @@ Template.detailtimetable.events({
 
     if (getGlobalSetting('showCustomFieldsInDetails')) {
       if (CustomFields.find({ classname: 'time_entry' }).count() > 0) {
-        csvArray[0] = `${csvArray[0]},${CustomFields.find({ classname: 'time_entry' }).fetch().map((field) => field.name).join(',')}`
+        csvArray[0] = `${csvArray[0]},${CustomFields.find({ classname: 'time_entry' }).fetch().map((field) => field[customFieldType]).join(',')}`
       }
       if (CustomFields.find({ classname: 'project' }).count() > 0) {
-        csvArray[0] = `${csvArray[0]},${CustomFields.find({ classname: 'project' }).fetch().map((field) => field.name).join(',')}`
+        csvArray[0] = `${csvArray[0]},${CustomFields.find({ classname: 'project' }).fetch().map((field) => field[customFieldType]).join(',')}`
       }
     }
     if (getGlobalSetting('showCustomerInDetails')) {
@@ -338,12 +343,12 @@ Template.detailtimetable.events({
     if (getGlobalSetting('showCustomFieldsInDetails')) {
       if (CustomFields.find({ classname: 'time_entry' }).count() > 0) {
         for (const customfield of CustomFields.find({ classname: 'time_entry' }).fetch()) {
-          data[0].push(customfield.name)
+          data[0].push(customfield[customFieldType])
         }
       }
       if (CustomFields.find({ classname: 'project' }).count() > 0) {
         for (const customfield of CustomFields.find({ classname: 'project' }).fetch()) {
-          data[0].push(customfield.name)
+          data[0].push(customfield[customFieldType])
         }
       }
     }

--- a/imports/ui/components/detailtimetable.js
+++ b/imports/ui/components/detailtimetable.js
@@ -130,7 +130,7 @@ Template.detailtimetable.onRendered(() => {
         if (CustomFields.find({ classname: 'time_entry' }).count() > 0) {
           for (const customfield of CustomFields.find({ classname: 'time_entry' }).fetch()) {
             columns.push({
-              name: customfield.desc,
+              name: customfield.name,
               editable: false,
               format: addToolTipToTableCell,
             })
@@ -139,7 +139,7 @@ Template.detailtimetable.onRendered(() => {
         if (CustomFields.find({ classname: 'project' }).count() > 0) {
           for (const customfield of CustomFields.find({ classname: 'project' }).fetch()) {
             columns.push({
-              name: customfield.desc,
+              name: customfield.name,
               editable: false,
               format: addToolTipToTableCell,
             })
@@ -296,10 +296,10 @@ Template.detailtimetable.events({
 
     if (getGlobalSetting('showCustomFieldsInDetails')) {
       if (CustomFields.find({ classname: 'time_entry' }).count() > 0) {
-        csvArray[0] = `${csvArray[0]},${CustomFields.find({ classname: 'time_entry' }).fetch().map((field) => field.desc).join(',')}`
+        csvArray[0] = `${csvArray[0]},${CustomFields.find({ classname: 'time_entry' }).fetch().map((field) => field.name).join(',')}`
       }
       if (CustomFields.find({ classname: 'project' }).count() > 0) {
-        csvArray[0] = `${csvArray[0]},${CustomFields.find({ classname: 'project' }).fetch().map((field) => field.desc).join(',')}`
+        csvArray[0] = `${csvArray[0]},${CustomFields.find({ classname: 'project' }).fetch().map((field) => field.name).join(',')}`
       }
     }
     if (getGlobalSetting('showCustomerInDetails')) {
@@ -338,12 +338,12 @@ Template.detailtimetable.events({
     if (getGlobalSetting('showCustomFieldsInDetails')) {
       if (CustomFields.find({ classname: 'time_entry' }).count() > 0) {
         for (const customfield of CustomFields.find({ classname: 'time_entry' }).fetch()) {
-          data[0].push(customfield.desc)
+          data[0].push(customfield.name)
         }
       }
       if (CustomFields.find({ classname: 'project' }).count() > 0) {
         for (const customfield of CustomFields.find({ classname: 'project' }).fetch()) {
-          data[0].push(customfield.desc)
+          data[0].push(customfield.name)
         }
       }
     }

--- a/imports/ui/translations/de.json
+++ b/imports/ui/translations/de.json
@@ -163,7 +163,8 @@
     "custom_html": "Benuzterdefiniertes HTML",
     "custom_placeholder_content": "Benutzerdefinierter Inhalt für den Platzhalter",
     "show_custom_fields_in_details": "Benutzerdefinierte Felder in den Details anzeigen/exportieren?",
-    "show_customer_in_details": "Spalte Kunde in den Details anzeigen/exportieren?"
+    "show_customer_in_details": "Spalte Kunde in den Details anzeigen/exportieren?",
+    "show_name_custom_field_in_details": "Namen für benutzerdefinierte Felder in der Detailansicht anzeigen?"
   },
   "customer": {
     "select_customer": "Kunde auswählen",

--- a/imports/ui/translations/en.json
+++ b/imports/ui/translations/en.json
@@ -164,7 +164,8 @@
     "custom_html": "Custom HTML",
     "custom_placeholder_content": "Custom Placeholder Content",
     "show_custom_fields_in_details": "Show/export custom fields in details view?",
-    "show_customer_in_details": "Show/export customer field in details view?"
+    "show_customer_in_details": "Show/export customer field in details view?",
+    "show_name_custom_field_in_details": "Show name for custom fields in details view?"
   },
   "customer": {
     "select_customer": "Select a customer",

--- a/imports/ui/translations/fr.json
+++ b/imports/ui/translations/fr.json
@@ -155,7 +155,8 @@
     "zammad_api_token": "Clef d'accès personnel Zammad",
     "custom_css": "CSS personnalisé",
     "custom_html": "HTML personnalisé",
-    "custom_placeholder_content": "Contenu de placeholder personnalisé"
+    "custom_placeholder_content": "Contenu de placeholder personnalisé",
+    "show_name_custom_field_in_details": "Afficher le nom des champs personnalisés dans la vue détaillée ?"
   },
   "customer": {
     "select_customer": "Selectionner un client",


### PR DESCRIPTION
Use the short name instead of the long description of a custom field in the overview page.