### PR TITLE
Add support for disabling the default login form when using OIDC

### DIFF
--- a/imports/startup/server/useraccounts-configuration.js
+++ b/imports/startup/server/useraccounts-configuration.js
@@ -3,9 +3,9 @@ import dockerNames from 'docker-names'
 import { getGlobalSetting } from '../../utils/frontend_helpers'
 import initNewUser from '../../api/projects/setup.js'
 
-Accounts.setAdditionalFindUserOnExternalLogin(async (user) => {
-  if (user.serviceName === 'oidc' && user?.options?.emails?.[0]) {
-    return Meteor.users.findOneAsync({ 'emails.0.address': user.options.emails[0].address })
+Accounts.setAdditionalFindUserOnExternalLogin(({serviceName, serviceData}) => {
+  if (serviceName === 'oidc') {
+    return Accounts.findUserByEmail(serviceData.email);
   }
   return undefined
 })

--- a/imports/ui/pages/administration/components/oidccomponent.html
+++ b/imports/ui/pages/administration/components/oidccomponent.html
@@ -15,8 +15,12 @@
                     {{#each setting in oidcSettings}}
                     <tr>
                         <td>{{setting.label}}</td>
-                        <td>
-                            <input aria-label='{{setting.label}}' id="configure-oidc-{{setting.property}}" name="{{setting.property}}" type="text" value="{{oidcValue setting.property}}" class="form-control js-setting-input"/>
+                        <td class="form-switch">
+                            {{#if isCheckbox setting}}
+                                <input aria-label="{{setting.label}}" id="configure-oidc-{{setting.property}}" name="{{setting.property}}" type="checkbox" class="form-check-input js-setting-input form-checkbox" {{isChecked setting.property}}/>
+                            {{else}}
+                                <input aria-label='{{setting.label}}' id="configure-oidc-{{setting.property}}" name="{{setting.property}}" type="text" value="{{oidcValue setting.property}}" class="form-control js-setting-input"/>
+                            {{/if}}
                         </td>
                     </tr>
                     {{/each}}

--- a/imports/ui/pages/administration/components/oidccomponent.js
+++ b/imports/ui/pages/administration/components/oidccomponent.js
@@ -7,20 +7,24 @@ Template.oidccomponent.helpers({
   oidcSettings: () => oidcFields,
   oidcValue: (name) => getOidcConfiguration(name),
   siteUrl: () => Meteor.absoluteUrl({ replaceLocalhost: true }),
+  isCheckbox: (setting) => setting.type === 'checkbox',
+  isChecked: (name) => getOidcConfiguration(name) ? 'checked' : '',  
 })
 Template.oidccomponent.events({
-  'click .js-update-oidc': (event) => {
+  'click .js-update-oidc': (event, templateInstance) => {
     event.preventDefault()
     const configuration = {
       service: 'oidc',
       loginStyle: 'popup',
     }
-    // Fetch the value of each input field
-    oidcFields.forEach((field) => {
-      configuration[field.property] = document.getElementById(
-        `configure-oidc-${field.property}`,
-      ).value.replace(/^\s*|\s*$/g, '') // trim() doesnt work on IE8
-    })
+    for (const element of templateInstance.$('.js-setting-input')) {
+      const { name } = element
+      let value = templateInstance.$(element).val()
+      if (element.type === 'checkbox') {
+        value = templateInstance.$(element).is(':checked')
+      }
+      configuration[name] = value
+    }
     configuration.idTokenWhitelistFields = configuration.idTokenWhitelistFields.split(' ')
     // Configure this login service
     Meteor.call('updateOidcSettings', { configuration }, (error) => {

--- a/imports/ui/pages/signIn.html
+++ b/imports/ui/pages/signIn.html
@@ -8,6 +8,7 @@
           </div>
           <div class="alert alert-danger notification d-none" role="alert">
           </div>
+          {{#unless disableDefaultLoginForm}}
           <div class="at-pwd-form">
             <form role="form" id="at-pwd-form" novalidate="">
               <fieldset>
@@ -36,6 +37,7 @@
               </fieldset>
             </form>
           </div>
+          {{/unless}}
 
           {{#if isOidcConfigured}}
           <div class="mt-2">

--- a/imports/ui/pages/signIn.js
+++ b/imports/ui/pages/signIn.js
@@ -1,6 +1,6 @@
 import { FlowRouter } from 'meteor/ostrio:flow-router-extra'
 import { validateEmail, getGlobalSetting } from '../../utils/frontend_helpers'
-import { isOidcConfigured } from '../../utils/oidc_helper'
+import { isOidcConfigured, disableDefaultLoginForm } from '../../utils/oidc_helper'
 import { t } from '../../utils/i18n.js'
 import './signIn.html'
 
@@ -51,7 +51,8 @@ function signIn(event, templateInstance) {
 
 Template.signIn.helpers({
   isOidcConfigured: () => isOidcConfigured(),
-  disableUserRegistration: () => getGlobalSetting('disableUserRegistration'),
+  disableUserRegistration: () => getGlobalSetting('disableUserRegistration') || disableDefaultLoginForm(),
+  disableDefaultLoginForm:() => disableDefaultLoginForm(),
 })
 
 Template.signIn.events({

--- a/imports/utils/oidc_helper.js
+++ b/imports/utils/oidc_helper.js
@@ -4,13 +4,14 @@ import { getGlobalSetting } from './frontend_helpers'
 const SERVICE_NAME = 'oidc'
 
 const oidcFields = [
-  { property: 'clientId', label: 'Client ID' },
-  { property: 'secret', label: 'Client Secret' },
-  { property: 'serverUrl', label: 'OIDC Server URL' },
-  { property: 'authorizationEndpoint', label: 'Authorization Endpoint' },
-  { property: 'tokenEndpoint', label: 'Token Endpoint' },
-  { property: 'userinfoEndpoint', label: 'Userinfo Endpoint' },
-  { property: 'idTokenWhitelistFields', label: 'Id Token Fields' },
+  { property: 'disableDefaultLoginForm', label: 'Disable Default Login Form', type: 'checkbox', value: false },
+  { property: 'clientId', label: 'Client ID', type: 'text', value: '' },
+  { property: 'secret', label: 'Client Secret', type: 'text', value: '' },
+  { property: 'serverUrl', label: 'OIDC Server URL', type: 'text', value: '' },
+  { property: 'authorizationEndpoint', label: 'Authorization Endpoint', type: 'text', value: '' },
+  { property: 'tokenEndpoint', label: 'Token Endpoint', type: 'text', value: '' },
+  { property: 'userinfoEndpoint', label: 'Userinfo Endpoint', type: 'text', value: '' },
+  { property: 'idTokenWhitelistFields', label: 'Id Token Fields', type: 'text', value: '' },
 ]
 
 function isOidcConfigured() {
@@ -20,6 +21,19 @@ function isOidcConfigured() {
   return false
 }
 
+function disableDefaultLoginForm() {
+  if (!getGlobalSetting('enableOpenIDConnect')) {
+    return false
+  }
+
+  var configuration = ServiceConfiguration.configurations.findOne({ service: SERVICE_NAME });
+  if (configuration == undefined) {
+    return false
+  }
+
+  return configuration.disableDefaultLoginForm
+}
+
 function getOidcConfiguration(name) {
   if (getGlobalSetting('enableOpenIDConnect')) {
     return ServiceConfiguration.configurations.findOne({ service: SERVICE_NAME })
@@ -27,4 +41,4 @@ function getOidcConfiguration(name) {
   }
   return ''
 }
-export { oidcFields, isOidcConfigured, getOidcConfiguration }
+export { oidcFields, isOidcConfigured, disableDefaultLoginForm, getOidcConfiguration }


### PR DESCRIPTION
This PR adds a new property to the OIDC configuration page to optionally disable the default login form. The behaviour of this feature has been tested as follows:

- Default login screen appears on a fresh install (tested by deleting `.meteor/local/db`).
- Default login screen appears when OIDC is first enabled (as disable toggle is OFF by default).
- Default login screen DOES NOT appear when OIDC is enabled and the toggle is set to true.
- Default login screen appears when OIDC has been disabled, even if the feature toggle is still set to true.

In addition the Register button is also removed when in OIDC mode regardless of whether you have the setting turned on or not. The assumption here being that you just want users to login and have meteor create them a new account (if you are accepting new registrations). This prevents people creating the "wrong" type of login.

This is a small quality of life / UX thing but should make it more obvious how you want users to log in.

### New Form Option
![Form](https://user-images.githubusercontent.com/42525567/223077004-e6451fd7-7198-4a6a-a009-8b02d0ed07e6.png)

### Sign In Page With New Option Enabled
![Sign In](https://user-images.githubusercontent.com/42525567/223077138-b9d09cae-e6a5-4655-82ed-f8414a881dd8.png)

I appreciate this one might need a bit more testing to make sure it's right given it effects login. I found the best way to test this was have two browsers open (one normal, one incognito). Any changes made in the admin panel immediately effect the second browser instance so you can quickly test most use cases. Also you don't need an actual OIDC server to test this as you don't need to go through the OIDC login flow if you keep the two browser instances open 👍.